### PR TITLE
fix(validators): add option for max/min value to not include treshold

### DIFF
--- a/src/tests/validators/validators.test.js
+++ b/src/tests/validators/validators.test.js
@@ -92,12 +92,16 @@ describe('New validators', () => {
       expect(validatorMapper(validators.MIN_NUMBER_VALUE)({ value: 99 })(123)).toBeUndefined();
     });
 
+    it('should pass the validation if minimum value', () => {
+      expect(validatorMapper(validators.MIN_NUMBER_VALUE)({ value: 99 })(99)).toBeUndefined();
+    });
+
     it('should pass the validation if no input given', () => {
       expect(validatorMapper(validators.MIN_NUMBER_VALUE)({ value: 99 })()).toBeUndefined();
     });
 
-    it('should not pass the validation', () => {
-      expect(validatorMapper(validators.MIN_NUMBER_VALUE)({ value: 99 })(1)).toEqual('Value must be greater than 99.');
+    it('should not pass the validation (includeTreshold is false)', () => {
+      expect(validatorMapper(validators.MIN_NUMBER_VALUE)({ value: 99, includeThreshold: false })(99)).toEqual('Value must be greater than 99.');
     });
 
     it('should not pass the validation and return custom message', () => {
@@ -110,12 +114,16 @@ describe('New validators', () => {
       expect(validatorMapper(validators.MAX_NUMBER_VALUE)({ value: 99 })(1)).toBeUndefined();
     });
 
+    it('should pass the validation if maximum value', () => {
+      expect(validatorMapper(validators.MAX_NUMBER_VALUE)({ value: 99 })(99)).toBeUndefined();
+    });
+
     it('should pass the validation if no input given', () => {
       expect(validatorMapper(validators.MAX_NUMBER_VALUE)({ value: 99 })()).toBeUndefined();
     });
 
-    it('should not pass the validation', () => {
-      expect(validatorMapper(validators.MAX_NUMBER_VALUE)({ value: 99 })(123)).toEqual('Value must be less than 99');
+    it('should not pass the validation (includeTreshold is false)', () => {
+      expect(validatorMapper(validators.MAX_NUMBER_VALUE)({ value: 99, includeThreshold: false })(99)).toEqual('Value must be less than 99');
     });
 
     it('should not pass the validation and return custom validation', () => {

--- a/src/validators/validator-mapper.js
+++ b/src/validators/validator-mapper.js
@@ -10,6 +10,8 @@ export default validatorType => ({
   [validators.MIN_ITEMS_VALIDATOR]: ({ treshold, ...rest }) =>
     length({ minimum: treshold, message: `Must have at least ${treshold} items.`, ...rest }),
   [validators.PATTERN_VALIDATOR]: pattern,
-  [validators.MAX_NUMBER_VALUE]: ({ value, ...rest }) => numericality({ '<': value, ...rest }),
-  [validators.MIN_NUMBER_VALUE]: ({ value, ...rest }) => numericality({ '>': value, ...rest }),
+  [validators.MAX_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
+    numericality({ [includeThreshold ? '<=' : '<']: value, ...rest }),
+  [validators.MIN_NUMBER_VALUE]: ({ value, includeThreshold = true, ...rest }) =>
+    numericality({ [includeThreshold ? '>=' : '>']: value, ...rest }),
 })[validatorType];


### PR DESCRIPTION
Max/Min value was not included in range of their validators `(Min, ...)   (..., Max)`. Now, **they are included by default: `<Min, ...)   (..., Max>` !!!**

User can use `includeTreshold: false` in validator to set the interval open.