### PR TITLE
fix(renderForm): adds clearOnUnmount option

### DIFF
--- a/src/form-renderer/index.js
+++ b/src/form-renderer/index.js
@@ -37,6 +37,7 @@ const FormRenderer = ({
   showFormControls,
   buttonOrder,
   buttonClassName,
+  clearOnUnmount,
 }) => {
   const inputSchema = schemaMapper(schemaType)(schema, uiSchema);
   let schemaError;
@@ -71,7 +72,7 @@ const FormRenderer = ({
               <FormWrapper>
                 { inputSchema.schema.title && renderTitle(inputSchema.schema.title) }
                 { inputSchema.schema.description && renderDescription(inputSchema.schema.description) }
-                { renderForm(inputSchema.schema.fields, { push: mutators.push, change, pristine, onSubmit, onCancel, getState, valid, submit, handleSubmit, reset, ...form }) }
+                { renderForm(inputSchema.schema.fields, { push: mutators.push, change, pristine, onSubmit, onCancel, getState, valid, submit, handleSubmit, reset, clearOnUnmount, ...form }) }
                 { showFormControls && renderControls({
                   buttonOrder,
                   buttonClassName,
@@ -112,6 +113,7 @@ FormRenderer.propTypes = {
   showFormControls: PropTypes.bool,
   buttonOrder: PropTypes.arrayOf(PropTypes.string),
   buttonClassName: PropTypes.string,
+  clearOnUnmount: PropTypes.bool,
 };
 
 FormRenderer.defaultProps = {
@@ -123,4 +125,5 @@ FormRenderer.defaultProps = {
   initialValues: {},
   uiSchema: {},
   showFormControls: true,
+  clearOnUnmount: false,
 };

--- a/src/form-renderer/render-form.js
+++ b/src/form-renderer/render-form.js
@@ -40,6 +40,19 @@ const Condition = ({ when, is, isNotEmpty, isEmpty, children, pattern, notMatch 
   );
 };
 
+class FieldProvider extends React.Component{
+  componentWillUnmount(){
+    if ((this.props.formOptions.clearOnUnmount || this.props.clearOnUnmount) && this.props.clearOnUnmount !== false) {
+      this.props.formOptions.change(this.props.name, undefined);
+    }
+  }
+
+  render(){
+    const { clearOnUnmount, ...props } = this.props;
+    return <Field { ...props } />;
+  }
+}
+
 const FormConditionWrapper = ({ condition, children }) => (condition ? (
   <Condition { ...condition }>
     { children }
@@ -49,7 +62,7 @@ const FormConditionWrapper = ({ condition, children }) => (condition ? (
 const FieldWrapper = ({ componentType, validate, component, formOptions, assignFieldProvider, ...rest }) => {
   const componentProps = {
     type: assignSpecialType(componentType),
-    FieldProvider: Field,
+    FieldProvider,
     ...rest,
     formOptions,
     component,
@@ -78,8 +91,8 @@ const FieldWrapper = ({ componentType, validate, component, formOptions, assignF
 
   const Component = component;
   return shouldWrapInField(componentType)
-    ? <Field { ...componentProps } />
-    : <Component formOptions={ formOptions } validate={ composeValidators(validate) } { ...rest } FieldProvider={ Field } />;
+    ? <FieldProvider { ...componentProps } />
+    : <Component formOptions={ formOptions } validate={ composeValidators(validate) } { ...rest } FieldProvider={ FieldProvider } />;
 };
 
 const renderSingleField = ({ component, condition, ...rest }, formOptions) => (

--- a/src/tests/form-renderer/__snapshots__/array-form-component.test.js.snap
+++ b/src/tests/form-renderer/__snapshots__/array-form-component.test.js.snap
@@ -45,7 +45,7 @@ exports[`renderForm function should render array field correctly 1`] = `
           ]
         }
       >
-        <ReactFinalForm(Field)
+        <FieldProvider
           FieldProvider={[Function]}
           arrayValidator={[Function]}
           component={[Function]}
@@ -66,7 +66,7 @@ exports[`renderForm function should render array field correctly 1`] = `
           }
           name="foo"
         >
-          <Field
+          <ReactFinalForm(Field)
             FieldProvider={[Function]}
             arrayValidator={[Function]}
             component={[Function]}
@@ -85,44 +85,12 @@ exports[`renderForm function should render array field correctly 1`] = `
                 "renderForm": [Function],
               }
             }
-            format={[Function]}
             name="foo"
-            parse={[Function]}
-            reactFinalForm={
-              Object {
-                "batch": [Function],
-                "blur": [Function],
-                "change": [Function],
-                "focus": [Function],
-                "getFieldState": [Function],
-                "getRegisteredFields": [Function],
-                "getState": [Function],
-                "initialize": [Function],
-                "isValidationPaused": [Function],
-                "mutators": Object {
-                  "insert": [Function],
-                  "move": [Function],
-                  "pop": [Function],
-                  "push": [Function],
-                  "remove": [Function],
-                  "shift": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                },
-                "pauseValidation": [Function],
-                "registerField": [Function],
-                "reset": [Function],
-                "resumeValidation": [Function],
-                "setConfig": [Function],
-                "submit": [Function],
-                "subscribe": [Function],
-              }
-            }
           >
-            <Component
+            <Field
               FieldProvider={[Function]}
               arrayValidator={[Function]}
+              component={[Function]}
               fields={
                 Array [
                   Object {
@@ -138,37 +106,42 @@ exports[`renderForm function should render array field correctly 1`] = `
                   "renderForm": [Function],
                 }
               }
-              input={
+              format={[Function]}
+              name="foo"
+              parse={[Function]}
+              reactFinalForm={
                 Object {
-                  "name": "foo",
-                  "onBlur": [Function],
-                  "onChange": [Function],
-                  "onFocus": [Function],
-                  "value": "",
-                }
-              }
-              meta={
-                Object {
-                  "active": false,
-                  "data": Object {},
-                  "dirty": false,
-                  "dirtySinceLastSubmit": false,
-                  "error": undefined,
-                  "initial": undefined,
-                  "invalid": false,
-                  "modified": false,
-                  "pristine": true,
-                  "submitError": undefined,
-                  "submitFailed": false,
-                  "submitSucceeded": false,
-                  "submitting": false,
-                  "touched": false,
-                  "valid": true,
-                  "visited": false,
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
+                  "getState": [Function],
+                  "initialize": [Function],
+                  "isValidationPaused": [Function],
+                  "mutators": Object {
+                    "insert": [Function],
+                    "move": [Function],
+                    "pop": [Function],
+                    "push": [Function],
+                    "remove": [Function],
+                    "shift": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                  },
+                  "pauseValidation": [Function],
+                  "registerField": [Function],
+                  "reset": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
                 }
               }
             >
-              <renderArrayField
+              <Component
                 FieldProvider={[Function]}
                 arrayValidator={[Function]}
                 fields={
@@ -215,12 +188,10 @@ exports[`renderForm function should render array field correctly 1`] = `
                     "visited": false,
                   }
                 }
-                validate={Array []}
               >
-                <DynamicArray
+                <renderArrayField
                   FieldProvider={[Function]}
                   arrayValidator={[Function]}
-                  fieldKey="foo"
                   fields={
                     Array [
                       Object {
@@ -265,87 +236,138 @@ exports[`renderForm function should render array field correctly 1`] = `
                       "visited": false,
                     }
                   }
-                  renderForm={[Function]}
                   validate={Array []}
                 >
-                  <ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))
-                    key="foo"
-                    name="foo"
-                    validate={[Function]}
-                  >
-                    <ReactFinalFormFieldArray(4.8.1)(2.0.1)
-                      name="foo"
-                      reactFinalForm={
+                  <DynamicArray
+                    FieldProvider={[Function]}
+                    arrayValidator={[Function]}
+                    fieldKey="foo"
+                    fields={
+                      Array [
                         Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "initialize": [Function],
-                          "isValidationPaused": [Function],
-                          "mutators": Object {
-                            "insert": [Function],
-                            "move": [Function],
-                            "pop": [Function],
-                            "push": [Function],
-                            "remove": [Function],
-                            "shift": [Function],
-                            "swap": [Function],
-                            "unshift": [Function],
-                            "update": [Function],
-                          },
-                          "pauseValidation": [Function],
-                          "registerField": [Function],
-                          "reset": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                        }
+                          "component": "text-field",
+                          "label": "foo",
+                          "name": "nested component",
+                        },
+                      ]
+                    }
+                    formOptions={
+                      Object {
+                        "hasFixedItems": false,
+                        "renderForm": [Function],
                       }
+                    }
+                    input={
+                      Object {
+                        "name": "foo",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    renderForm={[Function]}
+                    validate={Array []}
+                  >
+                    <ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))
+                      key="foo"
+                      name="foo"
                       validate={[Function]}
                     >
-                      <Col
-                        xs={11}
+                      <ReactFinalFormFieldArray(4.8.1)(2.0.1)
+                        name="foo"
+                        reactFinalForm={
+                          Object {
+                            "batch": [Function],
+                            "blur": [Function],
+                            "change": [Function],
+                            "focus": [Function],
+                            "getFieldState": [Function],
+                            "getRegisteredFields": [Function],
+                            "getState": [Function],
+                            "initialize": [Function],
+                            "isValidationPaused": [Function],
+                            "mutators": Object {
+                              "insert": [Function],
+                              "move": [Function],
+                              "pop": [Function],
+                              "push": [Function],
+                              "remove": [Function],
+                              "shift": [Function],
+                              "swap": [Function],
+                              "unshift": [Function],
+                              "update": [Function],
+                            },
+                            "pauseValidation": [Function],
+                            "registerField": [Function],
+                            "reset": [Function],
+                            "resumeValidation": [Function],
+                            "setConfig": [Function],
+                            "submit": [Function],
+                            "subscribe": [Function],
+                          }
+                        }
+                        validate={[Function]}
                       >
-                        <div />
-                      </Col>
-                      <Col
-                        className="final-form-array-add-container"
-                        xs={1}
-                      >
-                        <div>
-                          <FormGroup>
-                            <div>
-                              <ButtonGroup
-                                className="pull-right"
-                              >
-                                <div>
-                                  <Button
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <button
+                        <Col
+                          xs={11}
+                        >
+                          <div />
+                        </Col>
+                        <Col
+                          className="final-form-array-add-container"
+                          xs={1}
+                        >
+                          <div>
+                            <FormGroup>
+                              <div>
+                                <ButtonGroup
+                                  className="pull-right"
+                                >
+                                  <div>
+                                    <Button
                                       onClick={[Function]}
                                       type="button"
-                                    />
-                                  </Button>
-                                </div>
-                              </ButtonGroup>
-                            </div>
-                          </FormGroup>
-                        </div>
-                      </Col>
-                    </ReactFinalFormFieldArray(4.8.1)(2.0.1)>
-                  </ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))>
-                </DynamicArray>
-              </renderArrayField>
-            </Component>
-          </Field>
-        </ReactFinalForm(Field)>
+                                    >
+                                      <button
+                                        onClick={[Function]}
+                                        type="button"
+                                      />
+                                    </Button>
+                                  </div>
+                                </ButtonGroup>
+                              </div>
+                            </FormGroup>
+                          </div>
+                        </Col>
+                      </ReactFinalFormFieldArray(4.8.1)(2.0.1)>
+                    </ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))>
+                  </DynamicArray>
+                </renderArrayField>
+              </Component>
+            </Field>
+          </ReactFinalForm(Field)>
+        </FieldProvider>
       </FieldWrapper>
     </FormConditionWrapper>
   </ReactFinalForm>
@@ -407,7 +429,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
           ]
         }
       >
-        <ReactFinalForm(Field)
+        <FieldProvider
           FieldProvider={[Function]}
           additionalItems={
             Object {
@@ -438,7 +460,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
           name="foo"
           title="Title"
         >
-          <Field
+          <ReactFinalForm(Field)
             FieldProvider={[Function]}
             additionalItems={
               Object {
@@ -466,43 +488,10 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                 "renderForm": [Function],
               }
             }
-            format={[Function]}
             name="foo"
-            parse={[Function]}
-            reactFinalForm={
-              Object {
-                "batch": [Function],
-                "blur": [Function],
-                "change": [Function],
-                "focus": [Function],
-                "getFieldState": [Function],
-                "getRegisteredFields": [Function],
-                "getState": [Function],
-                "initialize": [Function],
-                "isValidationPaused": [Function],
-                "mutators": Object {
-                  "insert": [Function],
-                  "move": [Function],
-                  "pop": [Function],
-                  "push": [Function],
-                  "remove": [Function],
-                  "shift": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                },
-                "pauseValidation": [Function],
-                "registerField": [Function],
-                "reset": [Function],
-                "resumeValidation": [Function],
-                "setConfig": [Function],
-                "submit": [Function],
-                "subscribe": [Function],
-              }
-            }
             title="Title"
           >
-            <Component
+            <Field
               FieldProvider={[Function]}
               additionalItems={
                 Object {
@@ -513,6 +502,7 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                 }
               }
               arrayValidator={[Function]}
+              component={[Function]}
               description="description"
               fields={
                 Array [
@@ -529,38 +519,43 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                   "renderForm": [Function],
                 }
               }
-              input={
+              format={[Function]}
+              name="foo"
+              parse={[Function]}
+              reactFinalForm={
                 Object {
-                  "name": "foo",
-                  "onBlur": [Function],
-                  "onChange": [Function],
-                  "onFocus": [Function],
-                  "value": "",
-                }
-              }
-              meta={
-                Object {
-                  "active": false,
-                  "data": Object {},
-                  "dirty": false,
-                  "dirtySinceLastSubmit": false,
-                  "error": undefined,
-                  "initial": undefined,
-                  "invalid": false,
-                  "modified": false,
-                  "pristine": true,
-                  "submitError": undefined,
-                  "submitFailed": false,
-                  "submitSucceeded": false,
-                  "submitting": false,
-                  "touched": false,
-                  "valid": true,
-                  "visited": false,
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
+                  "getState": [Function],
+                  "initialize": [Function],
+                  "isValidationPaused": [Function],
+                  "mutators": Object {
+                    "insert": [Function],
+                    "move": [Function],
+                    "pop": [Function],
+                    "push": [Function],
+                    "remove": [Function],
+                    "shift": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                  },
+                  "pauseValidation": [Function],
+                  "registerField": [Function],
+                  "reset": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
                 }
               }
               title="Title"
             >
-              <renderArrayField
+              <Component
                 FieldProvider={[Function]}
                 additionalItems={
                   Object {
@@ -617,9 +612,8 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                   }
                 }
                 title="Title"
-                validate={Array []}
               >
-                <FixedArrayField
+                <renderArrayField
                   FieldProvider={[Function]}
                   additionalItems={
                     Object {
@@ -675,48 +669,91 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                       "visited": false,
                     }
                   }
-                  renderForm={[Function]}
                   title="Title"
                   validate={Array []}
                 >
-                  <Col
-                    xs={12}
-                  >
-                    <div>
-                      <h3>
-                        Title
-                      </h3>
-                    </div>
-                  </Col>
-                  <Col
-                    xs={12}
-                  >
-                    <div>
-                      <p>
-                        description
-                      </p>
-                    </div>
-                  </Col>
-                  <FormConditionWrapper>
-                    <FieldWrapper
-                      component={[Function]}
-                      componentType="text-field"
-                      formOptions={
+                  <FixedArrayField
+                    FieldProvider={[Function]}
+                    additionalItems={
+                      Object {
+                        "component": "text-field",
+                        "fields": Array [],
+                        "key": 1,
+                        "name": "foo",
+                      }
+                    }
+                    arrayValidator={[Function]}
+                    description="description"
+                    fields={
+                      Array [
                         Object {
-                          "renderForm": [Function],
-                        }
+                          "component": "text-field",
+                          "label": "foo",
+                          "name": "nested component",
+                        },
+                      ]
+                    }
+                    formOptions={
+                      Object {
+                        "hasFixedItems": true,
+                        "renderForm": [Function],
                       }
-                      label="foo"
-                      name="nested component"
-                      validate={
-                        Array [
-                          undefined,
-                        ]
+                    }
+                    input={
+                      Object {
+                        "name": "foo",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
                       }
+                    }
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    renderForm={[Function]}
+                    title="Title"
+                    validate={Array []}
+                  >
+                    <Col
+                      xs={12}
                     >
-                      <ReactFinalForm(Field)
-                        FieldProvider={[Function]}
+                      <div>
+                        <h3>
+                          Title
+                        </h3>
+                      </div>
+                    </Col>
+                    <Col
+                      xs={12}
+                    >
+                      <div>
+                        <p>
+                          description
+                        </p>
+                      </div>
+                    </Col>
+                    <FormConditionWrapper>
+                      <FieldWrapper
                         component={[Function]}
+                        componentType="text-field"
                         formOptions={
                           Object {
                             "renderForm": [Function],
@@ -724,9 +761,13 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                         }
                         label="foo"
                         name="nested component"
-                        validate={[Function]}
+                        validate={
+                          Array [
+                            undefined,
+                          ]
+                        }
                       >
-                        <Field
+                        <FieldProvider
                           FieldProvider={[Function]}
                           component={[Function]}
                           formOptions={
@@ -734,122 +775,135 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                               "renderForm": [Function],
                             }
                           }
-                          format={[Function]}
                           label="foo"
                           name="nested component"
-                          parse={[Function]}
-                          reactFinalForm={
-                            Object {
-                              "batch": [Function],
-                              "blur": [Function],
-                              "change": [Function],
-                              "focus": [Function],
-                              "getFieldState": [Function],
-                              "getRegisteredFields": [Function],
-                              "getState": [Function],
-                              "initialize": [Function],
-                              "isValidationPaused": [Function],
-                              "mutators": Object {
-                                "insert": [Function],
-                                "move": [Function],
-                                "pop": [Function],
-                                "push": [Function],
-                                "remove": [Function],
-                                "shift": [Function],
-                                "swap": [Function],
-                                "unshift": [Function],
-                                "update": [Function],
-                              },
-                              "pauseValidation": [Function],
-                              "registerField": [Function],
-                              "reset": [Function],
-                              "resumeValidation": [Function],
-                              "setConfig": [Function],
-                              "submit": [Function],
-                              "subscribe": [Function],
-                            }
-                          }
                           validate={[Function]}
                         >
-                          <Component
+                          <ReactFinalForm(Field)
                             FieldProvider={[Function]}
+                            component={[Function]}
                             formOptions={
                               Object {
                                 "renderForm": [Function],
                               }
                             }
-                            input={
-                              Object {
-                                "name": "nested component",
-                                "onBlur": [Function],
-                                "onChange": [Function],
-                                "onFocus": [Function],
-                                "value": "",
-                              }
-                            }
                             label="foo"
-                            meta={
-                              Object {
-                                "active": false,
-                                "data": Object {},
-                                "dirty": false,
-                                "dirtySinceLastSubmit": false,
-                                "error": undefined,
-                                "initial": undefined,
-                                "invalid": false,
-                                "modified": false,
-                                "pristine": true,
-                                "submitError": undefined,
-                                "submitFailed": false,
-                                "submitSucceeded": false,
-                                "submitting": false,
-                                "touched": false,
-                                "valid": true,
-                                "visited": false,
-                              }
-                            }
+                            name="nested component"
+                            validate={[Function]}
                           >
-                            <div
-                              className="nested-item"
+                            <Field
+                              FieldProvider={[Function]}
+                              component={[Function]}
+                              formOptions={
+                                Object {
+                                  "renderForm": [Function],
+                                }
+                              }
+                              format={[Function]}
+                              label="foo"
+                              name="nested component"
+                              parse={[Function]}
+                              reactFinalForm={
+                                Object {
+                                  "batch": [Function],
+                                  "blur": [Function],
+                                  "change": [Function],
+                                  "focus": [Function],
+                                  "getFieldState": [Function],
+                                  "getRegisteredFields": [Function],
+                                  "getState": [Function],
+                                  "initialize": [Function],
+                                  "isValidationPaused": [Function],
+                                  "mutators": Object {
+                                    "insert": [Function],
+                                    "move": [Function],
+                                    "pop": [Function],
+                                    "push": [Function],
+                                    "remove": [Function],
+                                    "shift": [Function],
+                                    "swap": [Function],
+                                    "unshift": [Function],
+                                    "update": [Function],
+                                  },
+                                  "pauseValidation": [Function],
+                                  "registerField": [Function],
+                                  "reset": [Function],
+                                  "resumeValidation": [Function],
+                                  "setConfig": [Function],
+                                  "submit": [Function],
+                                  "subscribe": [Function],
+                                }
+                              }
+                              validate={[Function]}
                             >
-                              Text field
-                            </div>
-                          </Component>
-                        </Field>
-                      </ReactFinalForm(Field)>
-                    </FieldWrapper>
-                  </FormConditionWrapper>
-                  <FormConditionWrapper>
-                    <FieldWrapper
-                      component={[Function]}
-                      componentType="text-field"
-                      fields={Array []}
-                      formOptions={
-                        Object {
-                          "renderForm": [Function],
-                        }
-                      }
-                      key="1"
-                      name="foo"
-                      validate={
-                        Array [
-                          undefined,
-                        ]
-                      }
-                    >
-                      <ReactFinalForm(Field)
-                        FieldProvider={[Function]}
+                              <Component
+                                FieldProvider={[Function]}
+                                formOptions={
+                                  Object {
+                                    "renderForm": [Function],
+                                  }
+                                }
+                                input={
+                                  Object {
+                                    "name": "nested component",
+                                    "onBlur": [Function],
+                                    "onChange": [Function],
+                                    "onFocus": [Function],
+                                    "value": "",
+                                  }
+                                }
+                                label="foo"
+                                meta={
+                                  Object {
+                                    "active": false,
+                                    "data": Object {},
+                                    "dirty": false,
+                                    "dirtySinceLastSubmit": false,
+                                    "error": undefined,
+                                    "initial": undefined,
+                                    "invalid": false,
+                                    "modified": false,
+                                    "pristine": true,
+                                    "submitError": undefined,
+                                    "submitFailed": false,
+                                    "submitSucceeded": false,
+                                    "submitting": false,
+                                    "touched": false,
+                                    "valid": true,
+                                    "visited": false,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="nested-item"
+                                >
+                                  Text field
+                                </div>
+                              </Component>
+                            </Field>
+                          </ReactFinalForm(Field)>
+                        </FieldProvider>
+                      </FieldWrapper>
+                    </FormConditionWrapper>
+                    <FormConditionWrapper>
+                      <FieldWrapper
                         component={[Function]}
+                        componentType="text-field"
                         fields={Array []}
                         formOptions={
                           Object {
                             "renderForm": [Function],
                           }
                         }
+                        key="1"
                         name="foo"
-                        validate={[Function]}
+                        validate={
+                          Array [
+                            undefined,
+                          ]
+                        }
                       >
-                        <Field
+                        <FieldProvider
                           FieldProvider={[Function]}
                           component={[Function]}
                           fields={Array []}
@@ -858,95 +912,121 @@ exports[`renderForm function should render fixed array field correctly 1`] = `
                               "renderForm": [Function],
                             }
                           }
-                          format={[Function]}
                           name="foo"
-                          parse={[Function]}
-                          reactFinalForm={
-                            Object {
-                              "batch": [Function],
-                              "blur": [Function],
-                              "change": [Function],
-                              "focus": [Function],
-                              "getFieldState": [Function],
-                              "getRegisteredFields": [Function],
-                              "getState": [Function],
-                              "initialize": [Function],
-                              "isValidationPaused": [Function],
-                              "mutators": Object {
-                                "insert": [Function],
-                                "move": [Function],
-                                "pop": [Function],
-                                "push": [Function],
-                                "remove": [Function],
-                                "shift": [Function],
-                                "swap": [Function],
-                                "unshift": [Function],
-                                "update": [Function],
-                              },
-                              "pauseValidation": [Function],
-                              "registerField": [Function],
-                              "reset": [Function],
-                              "resumeValidation": [Function],
-                              "setConfig": [Function],
-                              "submit": [Function],
-                              "subscribe": [Function],
-                            }
-                          }
                           validate={[Function]}
                         >
-                          <Component
+                          <ReactFinalForm(Field)
                             FieldProvider={[Function]}
+                            component={[Function]}
                             fields={Array []}
                             formOptions={
                               Object {
                                 "renderForm": [Function],
                               }
                             }
-                            input={
-                              Object {
-                                "name": "foo",
-                                "onBlur": [Function],
-                                "onChange": [Function],
-                                "onFocus": [Function],
-                                "value": "",
-                              }
-                            }
-                            meta={
-                              Object {
-                                "active": false,
-                                "data": Object {},
-                                "dirty": false,
-                                "dirtySinceLastSubmit": false,
-                                "error": undefined,
-                                "initial": undefined,
-                                "invalid": false,
-                                "modified": false,
-                                "pristine": true,
-                                "submitError": undefined,
-                                "submitFailed": false,
-                                "submitSucceeded": false,
-                                "submitting": false,
-                                "touched": false,
-                                "valid": true,
-                                "visited": false,
-                              }
-                            }
+                            name="foo"
+                            validate={[Function]}
                           >
-                            <div
-                              className="nested-item"
+                            <Field
+                              FieldProvider={[Function]}
+                              component={[Function]}
+                              fields={Array []}
+                              formOptions={
+                                Object {
+                                  "renderForm": [Function],
+                                }
+                              }
+                              format={[Function]}
+                              name="foo"
+                              parse={[Function]}
+                              reactFinalForm={
+                                Object {
+                                  "batch": [Function],
+                                  "blur": [Function],
+                                  "change": [Function],
+                                  "focus": [Function],
+                                  "getFieldState": [Function],
+                                  "getRegisteredFields": [Function],
+                                  "getState": [Function],
+                                  "initialize": [Function],
+                                  "isValidationPaused": [Function],
+                                  "mutators": Object {
+                                    "insert": [Function],
+                                    "move": [Function],
+                                    "pop": [Function],
+                                    "push": [Function],
+                                    "remove": [Function],
+                                    "shift": [Function],
+                                    "swap": [Function],
+                                    "unshift": [Function],
+                                    "update": [Function],
+                                  },
+                                  "pauseValidation": [Function],
+                                  "registerField": [Function],
+                                  "reset": [Function],
+                                  "resumeValidation": [Function],
+                                  "setConfig": [Function],
+                                  "submit": [Function],
+                                  "subscribe": [Function],
+                                }
+                              }
+                              validate={[Function]}
                             >
-                              Text field
-                            </div>
-                          </Component>
-                        </Field>
-                      </ReactFinalForm(Field)>
-                    </FieldWrapper>
-                  </FormConditionWrapper>
-                </FixedArrayField>
-              </renderArrayField>
-            </Component>
-          </Field>
-        </ReactFinalForm(Field)>
+                              <Component
+                                FieldProvider={[Function]}
+                                fields={Array []}
+                                formOptions={
+                                  Object {
+                                    "renderForm": [Function],
+                                  }
+                                }
+                                input={
+                                  Object {
+                                    "name": "foo",
+                                    "onBlur": [Function],
+                                    "onChange": [Function],
+                                    "onFocus": [Function],
+                                    "value": "",
+                                  }
+                                }
+                                meta={
+                                  Object {
+                                    "active": false,
+                                    "data": Object {},
+                                    "dirty": false,
+                                    "dirtySinceLastSubmit": false,
+                                    "error": undefined,
+                                    "initial": undefined,
+                                    "invalid": false,
+                                    "modified": false,
+                                    "pristine": true,
+                                    "submitError": undefined,
+                                    "submitFailed": false,
+                                    "submitSucceeded": false,
+                                    "submitting": false,
+                                    "touched": false,
+                                    "valid": true,
+                                    "visited": false,
+                                  }
+                                }
+                              >
+                                <div
+                                  className="nested-item"
+                                >
+                                  Text field
+                                </div>
+                              </Component>
+                            </Field>
+                          </ReactFinalForm(Field)>
+                        </FieldProvider>
+                      </FieldWrapper>
+                    </FormConditionWrapper>
+                  </FixedArrayField>
+                </renderArrayField>
+              </Component>
+            </Field>
+          </ReactFinalForm(Field)>
+        </FieldProvider>
       </FieldWrapper>
     </FormConditionWrapper>
   </ReactFinalForm>

--- a/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
+++ b/src/tests/form-renderer/__snapshots__/form-information.test.js.snap
@@ -4,6 +4,7 @@ exports[`<FormControls /> should render with description 1`] = `
 <ContextWrapper>
   <FormRenderer
     buttonsLabels={Object {}}
+    clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
     formType="pf3"
@@ -123,6 +124,7 @@ exports[`<FormControls /> should render with title 1`] = `
 <ContextWrapper>
   <FormRenderer
     buttonsLabels={Object {}}
+    clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
     formType="pf3"
@@ -242,6 +244,7 @@ exports[`<FormControls /> should render with title and description 1`] = `
 <ContextWrapper>
   <FormRenderer
     buttonsLabels={Object {}}
+    clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
     formType="pf3"
@@ -367,6 +370,7 @@ exports[`<FormControls /> should render without title and description 1`] = `
 <ContextWrapper>
   <FormRenderer
     buttonsLabels={Object {}}
+    clearOnUnmount={false}
     disableSubmit={Array []}
     formFieldsMapper={Object {}}
     formType="pf3"

--- a/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
+++ b/src/tests/form-renderer/__snapshots__/form-renderer.test.js.snap
@@ -3,6 +3,7 @@
 exports[`<FormRenderer /> should render form from schema 1`] = `
 <FormRenderer
   buttonsLabels={Object {}}
+  clearOnUnmount={false}
   disableSubmit={Array []}
   formFieldsMapper={
     Object {
@@ -263,6 +264,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -338,6 +340,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -437,6 +440,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -531,6 +535,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -631,6 +636,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -726,6 +732,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -771,6 +778,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -802,7 +810,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               ]
             }
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
@@ -812,6 +820,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -839,7 +848,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               type="text"
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
                 component={[Function]}
@@ -849,6 +858,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
+                    "clearOnUnmount": false,
                     "focus": [Function],
                     "getFieldState": [Function],
                     "getRegisteredFields": [Function],
@@ -871,53 +881,22 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                format={[Function]}
                 label="secret"
                 name="secret"
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 type="text"
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
+                  component={[Function]}
                   default="I'm a hidden string."
                   formOptions={
                     Object {
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
+                      "clearOnUnmount": false,
                       "focus": [Function],
                       "getFieldState": [Function],
                       "getRegisteredFields": [Function],
@@ -940,46 +919,117 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  input={
-                    Object {
-                      "name": "secret",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "I'm a hidden string.",
-                    }
-                  }
+                  format={[Function]}
                   label="secret"
-                  meta={
+                  name="secret"
+                  parse={[Function]}
+                  reactFinalForm={
                     Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": "I'm a hidden string.",
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
                     }
                   }
                   type="text"
+                  validate={[Function]}
                 >
-                  <div
-                    className="nested-item"
+                  <Component
+                    FieldProvider={[Function]}
+                    autoFocus={false}
+                    default="I'm a hidden string."
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "valid": true,
+                      }
+                    }
+                    input={
+                      Object {
+                        "name": "secret",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "I'm a hidden string.",
+                      }
+                    }
+                    label="secret"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": "I'm a hidden string.",
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    type="text"
                   >
-                    Text field
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
+                    <div
+                      className="nested-item"
+                    >
+                      Text field
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
           </FieldWrapper>
         </FormConditionWrapper>
         <FormConditionWrapper>
@@ -993,6 +1043,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -1025,7 +1076,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               ]
             }
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
@@ -1035,6 +1086,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -1063,7 +1115,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               type="text"
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
                 component={[Function]}
@@ -1073,6 +1125,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
+                    "clearOnUnmount": false,
                     "focus": [Function],
                     "getFieldState": [Function],
                     "getRegisteredFields": [Function],
@@ -1095,54 +1148,23 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                format={[Function]}
                 label="A disabled field"
                 name="disabled"
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 title="A disabled field"
                 type="text"
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
+                  component={[Function]}
                   default="I am disabled."
                   formOptions={
                     Object {
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
+                      "clearOnUnmount": false,
                       "focus": [Function],
                       "getFieldState": [Function],
                       "getRegisteredFields": [Function],
@@ -1165,47 +1187,119 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  input={
-                    Object {
-                      "name": "disabled",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "I am disabled.",
-                    }
-                  }
+                  format={[Function]}
                   label="A disabled field"
-                  meta={
+                  name="disabled"
+                  parse={[Function]}
+                  reactFinalForm={
                     Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": "I am disabled.",
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
                     }
                   }
                   title="A disabled field"
                   type="text"
+                  validate={[Function]}
                 >
-                  <div
-                    className="nested-item"
+                  <Component
+                    FieldProvider={[Function]}
+                    autoFocus={false}
+                    default="I am disabled."
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "valid": true,
+                      }
+                    }
+                    input={
+                      Object {
+                        "name": "disabled",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "I am disabled.",
+                      }
+                    }
+                    label="A disabled field"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": "I am disabled.",
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    title="A disabled field"
+                    type="text"
                   >
-                    Text field
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
+                    <div
+                      className="nested-item"
+                    >
+                      Text field
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
           </FieldWrapper>
         </FormConditionWrapper>
         <FormConditionWrapper>
@@ -1219,6 +1313,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -1251,7 +1346,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               ]
             }
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
@@ -1261,6 +1356,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -1289,7 +1385,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               type="text"
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
                 component={[Function]}
@@ -1299,6 +1395,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
+                    "clearOnUnmount": false,
                     "focus": [Function],
                     "getFieldState": [Function],
                     "getRegisteredFields": [Function],
@@ -1321,54 +1418,23 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                format={[Function]}
                 label="A readonly field"
                 name="readonly"
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 title="A readonly field"
                 type="text"
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
+                  component={[Function]}
                   default="I am read-only."
                   formOptions={
                     Object {
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
+                      "clearOnUnmount": false,
                       "focus": [Function],
                       "getFieldState": [Function],
                       "getRegisteredFields": [Function],
@@ -1391,47 +1457,119 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  input={
-                    Object {
-                      "name": "readonly",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "I am read-only.",
-                    }
-                  }
+                  format={[Function]}
                   label="A readonly field"
-                  meta={
+                  name="readonly"
+                  parse={[Function]}
+                  reactFinalForm={
                     Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": "I am read-only.",
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
                     }
                   }
                   title="A readonly field"
                   type="text"
+                  validate={[Function]}
                 >
-                  <div
-                    className="nested-item"
+                  <Component
+                    FieldProvider={[Function]}
+                    autoFocus={false}
+                    default="I am read-only."
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "valid": true,
+                      }
+                    }
+                    input={
+                      Object {
+                        "name": "readonly",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "I am read-only.",
+                      }
+                    }
+                    label="A readonly field"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": "I am read-only.",
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    title="A readonly field"
+                    type="text"
                   >
-                    Text field
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
+                    <div
+                      className="nested-item"
+                    >
+                      Text field
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
           </FieldWrapper>
         </FormConditionWrapper>
         <FormConditionWrapper>
@@ -1445,6 +1583,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -1477,7 +1616,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               ]
             }
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
@@ -1487,6 +1626,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -1515,7 +1655,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               type="text"
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
                 component={[Function]}
@@ -1525,6 +1665,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
+                    "clearOnUnmount": false,
                     "focus": [Function],
                     "getFieldState": [Function],
                     "getRegisteredFields": [Function],
@@ -1547,54 +1688,23 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                format={[Function]}
                 label="Custom widget with options"
                 name="widgetOptions"
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 title="Custom widget with options"
                 type="text"
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
+                  component={[Function]}
                   default="I am yellow"
                   formOptions={
                     Object {
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
+                      "clearOnUnmount": false,
                       "focus": [Function],
                       "getFieldState": [Function],
                       "getRegisteredFields": [Function],
@@ -1617,47 +1727,119 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  input={
-                    Object {
-                      "name": "widgetOptions",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "I am yellow",
-                    }
-                  }
+                  format={[Function]}
                   label="Custom widget with options"
-                  meta={
+                  name="widgetOptions"
+                  parse={[Function]}
+                  reactFinalForm={
                     Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": "I am yellow",
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
                     }
                   }
                   title="Custom widget with options"
                   type="text"
+                  validate={[Function]}
                 >
-                  <div
-                    className="nested-item"
+                  <Component
+                    FieldProvider={[Function]}
+                    autoFocus={false}
+                    default="I am yellow"
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "valid": true,
+                      }
+                    }
+                    input={
+                      Object {
+                        "name": "widgetOptions",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "I am yellow",
+                      }
+                    }
+                    label="Custom widget with options"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": "I am yellow",
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    title="Custom widget with options"
+                    type="text"
                   >
-                    Text field
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
+                    <div
+                      className="nested-item"
+                    >
+                      Text field
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
           </FieldWrapper>
         </FormConditionWrapper>
         <FormConditionWrapper>
@@ -1670,6 +1852,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                 "batch": [Function],
                 "blur": [Function],
                 "change": [Function],
+                "clearOnUnmount": false,
                 "focus": [Function],
                 "getFieldState": [Function],
                 "getRegisteredFields": [Function],
@@ -1718,7 +1901,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               ]
             }
           >
-            <ReactFinalForm(Field)
+            <FieldProvider
               FieldProvider={[Function]}
               autoFocus={false}
               component={[Function]}
@@ -1727,6 +1910,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                   "batch": [Function],
                   "blur": [Function],
                   "change": [Function],
+                  "clearOnUnmount": false,
                   "focus": [Function],
                   "getFieldState": [Function],
                   "getRegisteredFields": [Function],
@@ -1771,7 +1955,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
               type="string"
               validate={[Function]}
             >
-              <Field
+              <ReactFinalForm(Field)
                 FieldProvider={[Function]}
                 autoFocus={false}
                 component={[Function]}
@@ -1780,6 +1964,7 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "batch": [Function],
                     "blur": [Function],
                     "change": [Function],
+                    "clearOnUnmount": false,
                     "focus": [Function],
                     "getFieldState": [Function],
                     "getRegisteredFields": [Function],
@@ -1802,7 +1987,6 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     "valid": true,
                   }
                 }
-                format={[Function]}
                 label="Custom select widget with options"
                 name="selectWidgetOptions"
                 options={
@@ -1821,50 +2005,20 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                     },
                   ]
                 }
-                parse={[Function]}
-                reactFinalForm={
-                  Object {
-                    "batch": [Function],
-                    "blur": [Function],
-                    "change": [Function],
-                    "focus": [Function],
-                    "getFieldState": [Function],
-                    "getRegisteredFields": [Function],
-                    "getState": [Function],
-                    "initialize": [Function],
-                    "isValidationPaused": [Function],
-                    "mutators": Object {
-                      "insert": [Function],
-                      "move": [Function],
-                      "pop": [Function],
-                      "push": [Function],
-                      "remove": [Function],
-                      "shift": [Function],
-                      "swap": [Function],
-                      "unshift": [Function],
-                      "update": [Function],
-                    },
-                    "pauseValidation": [Function],
-                    "registerField": [Function],
-                    "reset": [Function],
-                    "resumeValidation": [Function],
-                    "setConfig": [Function],
-                    "submit": [Function],
-                    "subscribe": [Function],
-                  }
-                }
                 title="Custom select widget with options"
                 type="string"
                 validate={[Function]}
               >
-                <Component
+                <Field
                   FieldProvider={[Function]}
                   autoFocus={false}
+                  component={[Function]}
                   formOptions={
                     Object {
                       "batch": [Function],
                       "blur": [Function],
                       "change": [Function],
+                      "clearOnUnmount": false,
                       "focus": [Function],
                       "getFieldState": [Function],
                       "getRegisteredFields": [Function],
@@ -1887,36 +2041,9 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       "valid": true,
                     }
                   }
-                  input={
-                    Object {
-                      "name": "selectWidgetOptions",
-                      "onBlur": [Function],
-                      "onChange": [Function],
-                      "onFocus": [Function],
-                      "value": "",
-                    }
-                  }
+                  format={[Function]}
                   label="Custom select widget with options"
-                  meta={
-                    Object {
-                      "active": false,
-                      "data": Object {},
-                      "dirty": false,
-                      "dirtySinceLastSubmit": false,
-                      "error": undefined,
-                      "initial": undefined,
-                      "invalid": false,
-                      "modified": false,
-                      "pristine": true,
-                      "submitError": undefined,
-                      "submitFailed": false,
-                      "submitSucceeded": false,
-                      "submitting": false,
-                      "touched": false,
-                      "valid": true,
-                      "visited": false,
-                    }
-                  }
+                  name="selectWidgetOptions"
                   options={
                     Array [
                       Object {
@@ -1933,17 +2060,131 @@ exports[`<FormRenderer /> should render form from schema 1`] = `
                       },
                     ]
                   }
+                  parse={[Function]}
+                  reactFinalForm={
+                    Object {
+                      "batch": [Function],
+                      "blur": [Function],
+                      "change": [Function],
+                      "focus": [Function],
+                      "getFieldState": [Function],
+                      "getRegisteredFields": [Function],
+                      "getState": [Function],
+                      "initialize": [Function],
+                      "isValidationPaused": [Function],
+                      "mutators": Object {
+                        "insert": [Function],
+                        "move": [Function],
+                        "pop": [Function],
+                        "push": [Function],
+                        "remove": [Function],
+                        "shift": [Function],
+                        "swap": [Function],
+                        "unshift": [Function],
+                        "update": [Function],
+                      },
+                      "pauseValidation": [Function],
+                      "registerField": [Function],
+                      "reset": [Function],
+                      "resumeValidation": [Function],
+                      "setConfig": [Function],
+                      "submit": [Function],
+                      "subscribe": [Function],
+                    }
+                  }
                   title="Custom select widget with options"
                   type="string"
+                  validate={[Function]}
                 >
-                  <div
-                    className="nested-item"
+                  <Component
+                    FieldProvider={[Function]}
+                    autoFocus={false}
+                    formOptions={
+                      Object {
+                        "batch": [Function],
+                        "blur": [Function],
+                        "change": [Function],
+                        "clearOnUnmount": false,
+                        "focus": [Function],
+                        "getFieldState": [Function],
+                        "getRegisteredFields": [Function],
+                        "getState": [Function],
+                        "handleSubmit": [Function],
+                        "initialize": [Function],
+                        "isValidationPaused": [Function],
+                        "onCancel": undefined,
+                        "onSubmit": [MockFunction],
+                        "pauseValidation": [Function],
+                        "pristine": true,
+                        "push": [Function],
+                        "registerField": [Function],
+                        "renderForm": [Function],
+                        "reset": [Function],
+                        "resumeValidation": [Function],
+                        "setConfig": [Function],
+                        "submit": [Function],
+                        "subscribe": [Function],
+                        "valid": true,
+                      }
+                    }
+                    input={
+                      Object {
+                        "name": "selectWidgetOptions",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    label="Custom select widget with options"
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    options={
+                      Array [
+                        Object {
+                          "disabled": undefined,
+                          "label": "Please Choose",
+                        },
+                        Object {
+                          "label": "Foo",
+                          "value": "foo",
+                        },
+                        Object {
+                          "label": "Bar",
+                          "value": "bar",
+                        },
+                      ]
+                    }
+                    title="Custom select widget with options"
+                    type="string"
                   >
-                    Select field
-                  </div>
-                </Component>
-              </Field>
-            </ReactFinalForm(Field)>
+                    <div
+                      className="nested-item"
+                    >
+                      Select field
+                    </div>
+                  </Component>
+                </Field>
+              </ReactFinalForm(Field)>
+            </FieldProvider>
           </FieldWrapper>
         </FormConditionWrapper>
         <FormControls

--- a/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -1422,12 +1422,16 @@ exports[`renderForm function should render array field 1`] = `
 <ContextWrapper
   layoutMapper={
     Object {
+      "ArrayFieldWrapper": [Function],
       "Button": [Function],
       "ButtonGroup": [Function],
       "Col": [Function],
+      "Description": [Function],
       "FormGroup": [Function],
+      "FormWrapper": [Function],
       "HelpBlock": [Function],
       "Icon": [Function],
+      "Title": [Function],
     }
   }
 >
@@ -1465,7 +1469,7 @@ exports[`renderForm function should render array field 1`] = `
           ]
         }
       >
-        <ReactFinalForm(Field)
+        <FieldProvider
           FieldProvider={[Function]}
           arrayValidator={[Function]}
           component={[Function]}
@@ -1478,7 +1482,7 @@ exports[`renderForm function should render array field 1`] = `
           }
           name="foo"
         >
-          <Field
+          <ReactFinalForm(Field)
             FieldProvider={[Function]}
             arrayValidator={[Function]}
             component={[Function]}
@@ -1489,44 +1493,12 @@ exports[`renderForm function should render array field 1`] = `
                 "renderForm": [Function],
               }
             }
-            format={[Function]}
             name="foo"
-            parse={[Function]}
-            reactFinalForm={
-              Object {
-                "batch": [Function],
-                "blur": [Function],
-                "change": [Function],
-                "focus": [Function],
-                "getFieldState": [Function],
-                "getRegisteredFields": [Function],
-                "getState": [Function],
-                "initialize": [Function],
-                "isValidationPaused": [Function],
-                "mutators": Object {
-                  "insert": [Function],
-                  "move": [Function],
-                  "pop": [Function],
-                  "push": [Function],
-                  "remove": [Function],
-                  "shift": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                },
-                "pauseValidation": [Function],
-                "registerField": [Function],
-                "reset": [Function],
-                "resumeValidation": [Function],
-                "setConfig": [Function],
-                "submit": [Function],
-                "subscribe": [Function],
-              }
-            }
           >
-            <Component
+            <Field
               FieldProvider={[Function]}
               arrayValidator={[Function]}
+              component={[Function]}
               fields={Array []}
               formOptions={
                 Object {
@@ -1534,37 +1506,42 @@ exports[`renderForm function should render array field 1`] = `
                   "renderForm": [Function],
                 }
               }
-              input={
+              format={[Function]}
+              name="foo"
+              parse={[Function]}
+              reactFinalForm={
                 Object {
-                  "name": "foo",
-                  "onBlur": [Function],
-                  "onChange": [Function],
-                  "onFocus": [Function],
-                  "value": "",
-                }
-              }
-              meta={
-                Object {
-                  "active": false,
-                  "data": Object {},
-                  "dirty": false,
-                  "dirtySinceLastSubmit": false,
-                  "error": undefined,
-                  "initial": undefined,
-                  "invalid": false,
-                  "modified": false,
-                  "pristine": true,
-                  "submitError": undefined,
-                  "submitFailed": false,
-                  "submitSucceeded": false,
-                  "submitting": false,
-                  "touched": false,
-                  "valid": true,
-                  "visited": false,
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
+                  "getState": [Function],
+                  "initialize": [Function],
+                  "isValidationPaused": [Function],
+                  "mutators": Object {
+                    "insert": [Function],
+                    "move": [Function],
+                    "pop": [Function],
+                    "push": [Function],
+                    "remove": [Function],
+                    "shift": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                  },
+                  "pauseValidation": [Function],
+                  "registerField": [Function],
+                  "reset": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
                 }
               }
             >
-              <renderArrayField
+              <Component
                 FieldProvider={[Function]}
                 arrayValidator={[Function]}
                 fields={Array []}
@@ -1603,12 +1580,10 @@ exports[`renderForm function should render array field 1`] = `
                     "visited": false,
                   }
                 }
-                validate={Array []}
               >
-                <DynamicArray
+                <renderArrayField
                   FieldProvider={[Function]}
                   arrayValidator={[Function]}
-                  fieldKey="foo"
                   fields={Array []}
                   formOptions={
                     Object {
@@ -1645,87 +1620,130 @@ exports[`renderForm function should render array field 1`] = `
                       "visited": false,
                     }
                   }
-                  renderForm={[Function]}
                   validate={Array []}
                 >
-                  <ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))
-                    key="foo"
-                    name="foo"
-                    validate={[Function]}
-                  >
-                    <ReactFinalFormFieldArray(4.8.1)(2.0.1)
-                      name="foo"
-                      reactFinalForm={
-                        Object {
-                          "batch": [Function],
-                          "blur": [Function],
-                          "change": [Function],
-                          "focus": [Function],
-                          "getFieldState": [Function],
-                          "getRegisteredFields": [Function],
-                          "getState": [Function],
-                          "initialize": [Function],
-                          "isValidationPaused": [Function],
-                          "mutators": Object {
-                            "insert": [Function],
-                            "move": [Function],
-                            "pop": [Function],
-                            "push": [Function],
-                            "remove": [Function],
-                            "shift": [Function],
-                            "swap": [Function],
-                            "unshift": [Function],
-                            "update": [Function],
-                          },
-                          "pauseValidation": [Function],
-                          "registerField": [Function],
-                          "reset": [Function],
-                          "resumeValidation": [Function],
-                          "setConfig": [Function],
-                          "submit": [Function],
-                          "subscribe": [Function],
-                        }
+                  <DynamicArray
+                    FieldProvider={[Function]}
+                    arrayValidator={[Function]}
+                    fieldKey="foo"
+                    fields={Array []}
+                    formOptions={
+                      Object {
+                        "hasFixedItems": false,
+                        "renderForm": [Function],
                       }
+                    }
+                    input={
+                      Object {
+                        "name": "foo",
+                        "onBlur": [Function],
+                        "onChange": [Function],
+                        "onFocus": [Function],
+                        "value": "",
+                      }
+                    }
+                    meta={
+                      Object {
+                        "active": false,
+                        "data": Object {},
+                        "dirty": false,
+                        "dirtySinceLastSubmit": false,
+                        "error": undefined,
+                        "initial": undefined,
+                        "invalid": false,
+                        "modified": false,
+                        "pristine": true,
+                        "submitError": undefined,
+                        "submitFailed": false,
+                        "submitSucceeded": false,
+                        "submitting": false,
+                        "touched": false,
+                        "valid": true,
+                        "visited": false,
+                      }
+                    }
+                    renderForm={[Function]}
+                    validate={Array []}
+                  >
+                    <ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))
+                      key="foo"
+                      name="foo"
                       validate={[Function]}
                     >
-                      <Col
-                        xs={11}
+                      <ReactFinalFormFieldArray(4.8.1)(2.0.1)
+                        name="foo"
+                        reactFinalForm={
+                          Object {
+                            "batch": [Function],
+                            "blur": [Function],
+                            "change": [Function],
+                            "focus": [Function],
+                            "getFieldState": [Function],
+                            "getRegisteredFields": [Function],
+                            "getState": [Function],
+                            "initialize": [Function],
+                            "isValidationPaused": [Function],
+                            "mutators": Object {
+                              "insert": [Function],
+                              "move": [Function],
+                              "pop": [Function],
+                              "push": [Function],
+                              "remove": [Function],
+                              "shift": [Function],
+                              "swap": [Function],
+                              "unshift": [Function],
+                              "update": [Function],
+                            },
+                            "pauseValidation": [Function],
+                            "registerField": [Function],
+                            "reset": [Function],
+                            "resumeValidation": [Function],
+                            "setConfig": [Function],
+                            "submit": [Function],
+                            "subscribe": [Function],
+                          }
+                        }
+                        validate={[Function]}
                       >
-                        <div />
-                      </Col>
-                      <Col
-                        className="final-form-array-add-container"
-                        xs={1}
-                      >
-                        <div>
-                          <FormGroup>
-                            <div>
-                              <ButtonGroup
-                                className="pull-right"
-                              >
-                                <div>
-                                  <Button
-                                    onClick={[Function]}
-                                    type="button"
-                                  >
-                                    <button
+                        <Component
+                          xs={11}
+                        >
+                          <div />
+                        </Component>
+                        <Component
+                          className="final-form-array-add-container"
+                          xs={1}
+                        >
+                          <div>
+                            <Component>
+                              <div>
+                                <Component
+                                  className="pull-right"
+                                >
+                                  <div>
+                                    <Component
                                       onClick={[Function]}
                                       type="button"
-                                    />
-                                  </Button>
-                                </div>
-                              </ButtonGroup>
-                            </div>
-                          </FormGroup>
-                        </div>
-                      </Col>
-                    </ReactFinalFormFieldArray(4.8.1)(2.0.1)>
-                  </ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))>
-                </DynamicArray>
-              </renderArrayField>
-            </Component>
-          </Field>
-        </ReactFinalForm(Field)>
+                                    >
+                                      <button
+                                        onClick={[Function]}
+                                        type="button"
+                                      />
+                                    </Component>
+                                  </div>
+                                </Component>
+                              </div>
+                            </Component>
+                          </div>
+                        </Component>
+                      </ReactFinalFormFieldArray(4.8.1)(2.0.1)>
+                    </ReactFinalForm(ReactFinalFormFieldArray(4.8.1)(2.0.1))>
+                  </DynamicArray>
+                </renderArrayField>
+              </Component>
+            </Field>
+          </ReactFinalForm(Field)>
+        </FieldProvider>
       </FieldWrapper>
     </FormConditionWrapper>
   </ReactFinalForm>
@@ -1783,54 +1801,60 @@ exports[`renderForm function should render single field form with custom compone
           name="foo"
           validate={[Function]}
         >
-          <ReactFinalForm(Field)
+          <FieldProvider
             name="foo"
             render={[Function]}
             validate={[Function]}
           >
-            <Field
-              format={[Function]}
+            <ReactFinalForm(Field)
               name="foo"
-              parse={[Function]}
-              reactFinalForm={
-                Object {
-                  "batch": [Function],
-                  "blur": [Function],
-                  "change": [Function],
-                  "focus": [Function],
-                  "getFieldState": [Function],
-                  "getRegisteredFields": [Function],
-                  "getState": [Function],
-                  "initialize": [Function],
-                  "isValidationPaused": [Function],
-                  "mutators": Object {
-                    "insert": [Function],
-                    "move": [Function],
-                    "pop": [Function],
-                    "push": [Function],
-                    "remove": [Function],
-                    "shift": [Function],
-                    "swap": [Function],
-                    "unshift": [Function],
-                    "update": [Function],
-                  },
-                  "pauseValidation": [Function],
-                  "registerField": [Function],
-                  "reset": [Function],
-                  "resumeValidation": [Function],
-                  "setConfig": [Function],
-                  "submit": [Function],
-                  "subscribe": [Function],
-                }
-              }
               render={[Function]}
               validate={[Function]}
             >
-              <div>
-                Custom component
-              </div>
-            </Field>
-          </ReactFinalForm(Field)>
+              <Field
+                format={[Function]}
+                name="foo"
+                parse={[Function]}
+                reactFinalForm={
+                  Object {
+                    "batch": [Function],
+                    "blur": [Function],
+                    "change": [Function],
+                    "focus": [Function],
+                    "getFieldState": [Function],
+                    "getRegisteredFields": [Function],
+                    "getState": [Function],
+                    "initialize": [Function],
+                    "isValidationPaused": [Function],
+                    "mutators": Object {
+                      "insert": [Function],
+                      "move": [Function],
+                      "pop": [Function],
+                      "push": [Function],
+                      "remove": [Function],
+                      "shift": [Function],
+                      "swap": [Function],
+                      "unshift": [Function],
+                      "update": [Function],
+                    },
+                    "pauseValidation": [Function],
+                    "registerField": [Function],
+                    "reset": [Function],
+                    "resumeValidation": [Function],
+                    "setConfig": [Function],
+                    "submit": [Function],
+                    "subscribe": [Function],
+                  }
+                }
+                render={[Function]}
+                validate={[Function]}
+              >
+                <div>
+                  Custom component
+                </div>
+              </Field>
+            </ReactFinalForm(Field)>
+          </FieldProvider>
         </customComponent>
       </FieldWrapper>
     </FormConditionWrapper>
@@ -1878,7 +1902,7 @@ exports[`renderForm function should render single field from defined componentTy
           ]
         }
       >
-        <ReactFinalForm(Field)
+        <FieldProvider
           FieldProvider={[Function]}
           component={[Function]}
           formOptions={
@@ -1889,7 +1913,7 @@ exports[`renderForm function should render single field from defined componentTy
           name="foo"
           validate={[Function]}
         >
-          <Field
+          <ReactFinalForm(Field)
             FieldProvider={[Function]}
             component={[Function]}
             formOptions={
@@ -1897,80 +1921,55 @@ exports[`renderForm function should render single field from defined componentTy
                 "renderForm": [Function],
               }
             }
-            format={[Function]}
             name="foo"
-            parse={[Function]}
-            reactFinalForm={
-              Object {
-                "batch": [Function],
-                "blur": [Function],
-                "change": [Function],
-                "focus": [Function],
-                "getFieldState": [Function],
-                "getRegisteredFields": [Function],
-                "getState": [Function],
-                "initialize": [Function],
-                "isValidationPaused": [Function],
-                "mutators": Object {
-                  "insert": [Function],
-                  "move": [Function],
-                  "pop": [Function],
-                  "push": [Function],
-                  "remove": [Function],
-                  "shift": [Function],
-                  "swap": [Function],
-                  "unshift": [Function],
-                  "update": [Function],
-                },
-                "pauseValidation": [Function],
-                "registerField": [Function],
-                "reset": [Function],
-                "resumeValidation": [Function],
-                "setConfig": [Function],
-                "submit": [Function],
-                "subscribe": [Function],
-              }
-            }
             validate={[Function]}
           >
-            <Component
+            <Field
               FieldProvider={[Function]}
+              component={[Function]}
               formOptions={
                 Object {
                   "renderForm": [Function],
                 }
               }
-              input={
+              format={[Function]}
+              name="foo"
+              parse={[Function]}
+              reactFinalForm={
                 Object {
-                  "name": "foo",
-                  "onBlur": [Function],
-                  "onChange": [Function],
-                  "onFocus": [Function],
-                  "value": "",
+                  "batch": [Function],
+                  "blur": [Function],
+                  "change": [Function],
+                  "focus": [Function],
+                  "getFieldState": [Function],
+                  "getRegisteredFields": [Function],
+                  "getState": [Function],
+                  "initialize": [Function],
+                  "isValidationPaused": [Function],
+                  "mutators": Object {
+                    "insert": [Function],
+                    "move": [Function],
+                    "pop": [Function],
+                    "push": [Function],
+                    "remove": [Function],
+                    "shift": [Function],
+                    "swap": [Function],
+                    "unshift": [Function],
+                    "update": [Function],
+                  },
+                  "pauseValidation": [Function],
+                  "registerField": [Function],
+                  "reset": [Function],
+                  "resumeValidation": [Function],
+                  "setConfig": [Function],
+                  "submit": [Function],
+                  "subscribe": [Function],
                 }
               }
-              meta={
-                Object {
-                  "active": false,
-                  "data": Object {},
-                  "dirty": false,
-                  "dirtySinceLastSubmit": false,
-                  "error": undefined,
-                  "initial": undefined,
-                  "invalid": false,
-                  "modified": false,
-                  "pristine": true,
-                  "submitError": undefined,
-                  "submitFailed": false,
-                  "submitSucceeded": false,
-                  "submitting": false,
-                  "touched": false,
-                  "valid": true,
-                  "visited": false,
-                }
-              }
+              validate={[Function]}
             >
-              <div
+              <Component
+                FieldProvider={[Function]}
                 formOptions={
                   Object {
                     "renderForm": [Function],
@@ -2006,11 +2005,48 @@ exports[`renderForm function should render single field from defined componentTy
                   }
                 }
               >
-                TextField
-              </div>
-            </Component>
-          </Field>
-        </ReactFinalForm(Field)>
+                <div
+                  formOptions={
+                    Object {
+                      "renderForm": [Function],
+                    }
+                  }
+                  input={
+                    Object {
+                      "name": "foo",
+                      "onBlur": [Function],
+                      "onChange": [Function],
+                      "onFocus": [Function],
+                      "value": "",
+                    }
+                  }
+                  meta={
+                    Object {
+                      "active": false,
+                      "data": Object {},
+                      "dirty": false,
+                      "dirtySinceLastSubmit": false,
+                      "error": undefined,
+                      "initial": undefined,
+                      "invalid": false,
+                      "modified": false,
+                      "pristine": true,
+                      "submitError": undefined,
+                      "submitFailed": false,
+                      "submitSucceeded": false,
+                      "submitting": false,
+                      "touched": false,
+                      "valid": true,
+                      "visited": false,
+                    }
+                  }
+                >
+                  TextField
+                </div>
+              </Component>
+            </Field>
+          </ReactFinalForm(Field)>
+        </FieldProvider>
       </FieldWrapper>
     </FormConditionWrapper>
   </ReactFinalForm>


### PR DESCRIPTION
**Description**

When using dynamic forms where more fields share the same name, the value is preserved when a user switch the field. You can disable this behavior by setting `clearOnUnmount` option in the renderer component or in the schema of the field. The option in the schema has always higher priority. (When `clearOnUnmount` is set in the renderer and the field is set to `false`, the field value will not be cleared.)

**Examples**

Renderer

```jsx
<FormRenderer
          layoutMapper={ layoutMapper }
          formFieldsMapper={ formFieldsMapper }
          schema={ schema }
          onSubmit={ submit }
          clearOnUnmount // <------- HERE 🍔
/>
```

Schema

```jsx
{
        component: componentTypes.TEXT_FIELD,
        name: 'shared_field',
        label: 'Value of this field will be cleared after unmounting! Be aware!',
        key: 1,
        clearOnUnmount: true, // <------- HERE 🍔
        condition: {
          when: 'something',
          is: 'something',
        },
}, {
        component: componentTypes.TEXT_FIELD,
        name: 'shared_field',
        label: 'Value of this field will be cleared after unmounting! Be aware!',
        key: 2,
        clearOnUnmount: true, // <------- HERE 🍔
        condition: {
          when: 'something',
          is: 'something else',
        },
}, {
        component: componentTypes.TEXT_FIELD,
        name: 'shared_field',
        label: 'Value of this field will not be cleared after unmounting! Be aware!',
        key: 3,
        clearOnUnmount: false, // <------- HERE 🍔
        condition: {
          when: 'something',
          is: 'something else and something',
        },
},
```