### PR TITLE
fix(FieldProvider): add default formOptions prop to prevent crashes

### DIFF
--- a/src/form-renderer/render-form.js
+++ b/src/form-renderer/render-form.js
@@ -53,6 +53,19 @@ class FieldProvider extends React.Component{
   }
 }
 
+FieldProvider.propTypes = {
+  formOptions: PropTypes.shape({
+    clearOnUnmount: PropTypes.bool,
+    change: PropTypes.func,
+  }),
+  name: PropTypes.string,
+  clearOnUnmount: PropTypes.bool,
+};
+
+FieldProvider.defaultProps = {
+  formOptions: {},
+};
+
 const FormConditionWrapper = ({ condition, children }) => (condition ? (
   <Condition { ...condition }>
     { children }

--- a/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
+++ b/src/tests/form-renderer/__snapshots__/render-form.test.js.snap
@@ -1802,16 +1802,19 @@ exports[`renderForm function should render single field form with custom compone
           validate={[Function]}
         >
           <FieldProvider
+            formOptions={Object {}}
             name="foo"
             render={[Function]}
             validate={[Function]}
           >
             <ReactFinalForm(Field)
+              formOptions={Object {}}
               name="foo"
               render={[Function]}
               validate={[Function]}
             >
               <Field
+                formOptions={Object {}}
                 format={[Function]}
                 name="foo"
                 parse={[Function]}


### PR DESCRIPTION
If your custom component implementation does not pass `formOptions` to to FieldProviders it will crash on unmount because it can't check if it should reset its values.

I've added default prop for `formOptions` to prevent runtime crashes.